### PR TITLE
Feature/upload image when creating blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Static Files ###
+uploads/

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -117,3 +117,25 @@ FRONTEND:
 - Updated styling for blog for consistency and aesthetics.
 - Updated 'Read More' button to make it functional when text length is more than 200.
 - Added a 'Back to Blogs' link in Full Blog page.
+- Merged feature/edit-blog and feature/read-more-and-button-styling branches into develop
+
+BACKEND:
+- Merged feature/add-tests to develop
+
+## 25 Sept 2025
+BACKEND:
+- Added branch feature/upload-image-when-creating-blog.
+- Updated createNewBlog method and added required classes to handle image upload request, saves file to uploads folder and saves image URL to DB.
+
+
+## 28 Sept 2025
+FRONTEND:
+- Added branch feature/upload-image-when-adding-new-blog-and-display-image.
+- Updated timeout for making HTTP requests to backend from 10 sec to 60 sec to allow longer request processing.
+- Updated Blogs section to display blogs with image if there is one.
+- Updated blog form for creating new blog to enable uploading one image and remove image, preview also available.
+- Updated stylings for blog form and image upload section.
+
+BACKEND:
+- Added System.out.println to print paths images being saved to disk.
+- Updated .gitignore to prevent resource folder - uploads/ - from being uploaded to online repository.

--- a/src/main/java/com/wenglam/baking_app/config/WebConfig.java
+++ b/src/main/java/com/wenglam/baking_app/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.wenglam.baking_app.config;
+
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+
+public class WebConfig implements WebMvcConfigurer{
+
+    @Value("${app.upload.dir:uploads}")
+    private String uploadDir;
+
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+
+        String location = "file:" + System.getProperty("user.dir") + "/" + uploadDir + "/";
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(location) // "file:uploads/"
+                .setCachePeriod(3600); // Cache for 1 hour
+    }
+    
+}

--- a/src/main/java/com/wenglam/baking_app/config/WebConfig.java
+++ b/src/main/java/com/wenglam/baking_app/config/WebConfig.java
@@ -1,20 +1,21 @@
 package com.wenglam.baking_app.config;
 
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class WebConfig implements WebMvcConfigurer{
 
     @Value("${app.upload.dir:uploads}")
     private String uploadDir;
 
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-
-        String location = "file:" + System.getProperty("user.dir") + "/" + uploadDir + "/";
-        registry.addResourceHandler("/uploads/**")
-                .addResourceLocations(location) // "file:uploads/"
+        String location = "file:" + System.getProperty("user.dir") + "/" + uploadDir + "/"; //System.getProperty("user.dir") = project root (JVM working directory)
+        
+        registry.addResourceHandler("/uploads/**") // Define the URL pattern to serve static files
+                .addResourceLocations(location) // "file:$projectpath/uploads/"
                 .setCachePeriod(3600); // Cache for 1 hour
     }
-    
 }

--- a/src/main/java/com/wenglam/baking_app/controller/BlogPostController.java
+++ b/src/main/java/com/wenglam/baking_app/controller/BlogPostController.java
@@ -1,19 +1,22 @@
 package com.wenglam.baking_app.controller;
 
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.wenglam.baking_app.entity.BlogPost;
+import com.wenglam.baking_app.service.FileStorageService;
 import com.wenglam.baking_app.service.IBlogPostService;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.RequestMapping;
-
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +27,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 @RequiredArgsConstructor // lombok - generate constructors
 // @CrossOrigin(origins = "http://localhost:5173")
 public class BlogPostController {
-
     private final IBlogPostService blogPostService;
+    private final FileStorageService fileStorageService;
 
     @GetMapping
     public ResponseEntity<?> getAllBlogPosts() {
@@ -37,8 +40,26 @@ public class BlogPostController {
         return ResponseEntity.ok(blogPostService.getBlogPostById(id));
     }
 
-    @PostMapping
-    public ResponseEntity<?> createBlogPost(@RequestBody BlogPost blogPost) {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> createBlogPost(@RequestParam String title, 
+                                            @RequestParam String content,
+                                            @RequestParam String author,
+                                            @RequestParam(required = false) MultipartFile imageFile) {
+        
+        String imageUrl = null;
+        if (imageFile != null && !imageFile.isEmpty()) {
+            // Save the file to disk and get the URL
+            imageUrl = fileStorageService.store(imageFile); // Placeholder URL
+            // In a real application, you would save the file and generate a proper URL
+        }
+
+        // Construct the BlogPost object from params
+        BlogPost blogPost = new BlogPost();
+        blogPost.setTitle(title);
+        blogPost.setContent(content);
+        blogPost.setAuthor(author);
+        blogPost.setImageUrl(imageUrl);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(blogPostService.createBlogPost(blogPost));
     }
 

--- a/src/main/java/com/wenglam/baking_app/entity/BlogPost.java
+++ b/src/main/java/com/wenglam/baking_app/entity/BlogPost.java
@@ -19,7 +19,6 @@ import lombok.Setter;
 @Entity
 @Table(name = "blog_post")
 public class BlogPost {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     // IDENTITY is a column property that makes column auto-increment its value for

--- a/src/main/java/com/wenglam/baking_app/service/FileStorageService.java
+++ b/src/main/java/com/wenglam/baking_app/service/FileStorageService.java
@@ -19,7 +19,7 @@ public class FileStorageService {
     @Value("${app.upload.dir:uploads}")
     private String uploadDir;
 
-    @Value("${app.public.base-url:}")
+    @Value("${app.public.base-url:http://localhost:8080}") // Base URL for constructing public URLs
     private String publicBaseUrl;
 
     private Path root;
@@ -28,7 +28,8 @@ public class FileStorageService {
     public void init() throws IOException {
         // Resolves to an absolute filesystem path (project working directory by default)
         root = Paths.get(uploadDir).toAbsolutePath().normalize();
-        Files.createDirectories(root);
+        Files.createDirectories(root); 
+        System.out.println("[FileStorageService] [Upload] Saving files under " + root.toAbsolutePath());
     }
 
     /**
@@ -39,10 +40,13 @@ public class FileStorageService {
 
         String extension = getExtension(file.getOriginalFilename());
         String filename = UUID.randomUUID().toString() + (extension.isEmpty() ? "" : "." + extension); // Unique filename
-        Path target = root.resolve(filename); // Absolute path to the target file
+        Path target = root.resolve(filename).normalize(); // Absolute path to the target file
+        System.out.println("[FileStorageService]: " + root.resolve(filename).toString());
+        System.out.println("[FileStorageService]: " + target.toString());
 
         try {
             Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING); // Save the file to disk
+            System.out.println("[FileStorageService] Stored file " + filename + " at " + target.toString());
         } catch (IOException e) {
             throw new RuntimeException("Failed to store file " + filename, e);
         }

--- a/src/main/java/com/wenglam/baking_app/service/FileStorageService.java
+++ b/src/main/java/com/wenglam/baking_app/service/FileStorageService.java
@@ -1,0 +1,62 @@
+package com.wenglam.baking_app.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.annotation.PostConstruct;
+
+@Service
+public class FileStorageService {
+    
+    @Value("${app.upload.dir:uploads}")
+    private String uploadDir;
+
+    @Value("${app.public.base-url:}")
+    private String publicBaseUrl;
+
+    private Path root;
+
+    @PostConstruct
+    public void init() throws IOException {
+        // Resolves to an absolute filesystem path (project working directory by default)
+        root = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Files.createDirectories(root);
+    }
+
+    /**
+     * Saves file to disk and return a URL that the app will serve.
+     */
+    public String store(MultipartFile file) {
+        if (file == null || file.isEmpty()) return null;
+
+        String extension = getExtension(file.getOriginalFilename());
+        String filename = UUID.randomUUID().toString() + (extension.isEmpty() ? "" : "." + extension); // Unique filename
+        Path target = root.resolve(filename); // Absolute path to the target file
+
+        try {
+            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING); // Save the file to disk
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store file " + filename, e);
+        }
+
+        String relativeUrl = "/uploads/" + filename;
+        if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+            return relativeUrl;
+        } 
+            return publicBaseUrl.replaceAll("/$", "") + relativeUrl;
+    }
+
+    private static String getExtension(String filename) {
+        if (filename == null) return "";
+        int dot = filename.lastIndexOf('.');
+        return dot >= 0 ? filename.substring(dot + 1) : "";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,6 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+# File Storage
+app.upload.dir=uploads
+


### PR DESCRIPTION
1. WebConfig - added to configure a new resource handler which defines a new URL pattern to serve static files: "http://localhost:8080/uploads/**" and respective resource location to look for the files.
2. BlogPostController - Updated createBlogPost method to accept multipart form data, saving it to uploads folder, and generate a URL to imageFile attribute of BlogPost.
3. FileStorageService - new class added to handle saving images to designated folder and returning the URL to serve the image.
4. application.properties - added new property for resource folder - uploads
5. .gitignore - added uploads folder so resources stay local and not uploaded to online repo.
6. DEVLOG.md - updated notes for this PR and frontend app changes.