### PR TITLE
Added Files for Containerisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.gitignore
+README.md
+mvnw
+mvnw.cmd
+src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official OpenJDK runtime as a parent image
+FROM eclipse-temurin:21-jre-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built jar file from target directory
+COPY target/baking-app-0.0.1-SNAPSHOT.jar app.jar
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run the jar file
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This PR adds containerisation support for the application:

- Introduces a Dockerfile to build and run the Spring Boot jar inside a lightweight JRE base image.
- Adds a .dockerignore file to prevent unnecessary files (target/, .git/, logs, etc.) from being included in the Docker build context.
