### PR TITLE
Added Exception Handling for Tasty Feign Client

### DIFF
--- a/src/main/java/com/wenglam/baking_app/config/TastyApiProperties.java
+++ b/src/main/java/com/wenglam/baking_app/config/TastyApiProperties.java
@@ -17,6 +17,14 @@ public class TastyApiProperties {
 
     @PostConstruct
     public void init() {
-        log.info("TastyApiProperties initialized with rapidApiHost: " + rapidapiHost + " and rapidApiKey: " + rapidapiKey);
+        if (rapidapiHost == null || rapidapiHost.isEmpty()) {
+            log.warn("TastyApiProperties: rapidApiHost is not set. Make sure to set it in production.");
+        }
+
+        if (rapidapiKey == null || rapidapiKey.isEmpty()) {
+            log.warn("TastyApiProperties: rapidApiKey is not set. Make sure to set it in production.");
+        }
+
+        log.info("TastyApiProperties initialized with rapidApiHost: " + rapidapiHost + " and rapidApiKey.");
     }
  }

--- a/src/main/java/com/wenglam/baking_app/config/TastyFeignConfig.java
+++ b/src/main/java/com/wenglam/baking_app/config/TastyFeignConfig.java
@@ -1,0 +1,23 @@
+package com.wenglam.baking_app.config;
+
+import feign.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.wenglam.baking_app.external.tasty.TastyErrorDecoder;
+
+import feign.codec.ErrorDecoder;
+
+@Configuration
+public class TastyFeignConfig {
+
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new TastyErrorDecoder();
+    }
+}

--- a/src/main/java/com/wenglam/baking_app/exception/ApiNotSubscribedException.java
+++ b/src/main/java/com/wenglam/baking_app/exception/ApiNotSubscribedException.java
@@ -1,0 +1,7 @@
+package com.wenglam.baking_app.exception;
+
+public class ApiNotSubscribedException extends RuntimeException {
+    public ApiNotSubscribedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/wenglam/baking_app/exception/ExternalApiException.java
+++ b/src/main/java/com/wenglam/baking_app/exception/ExternalApiException.java
@@ -1,0 +1,16 @@
+package com.wenglam.baking_app.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ExternalApiException extends RuntimeException {
+
+    private final String provider;
+    private final int statusCode;
+
+    public ExternalApiException(String provider, int status, String message, Throwable cause) {
+        super(message, cause);
+        this.provider = provider;
+        this.statusCode = status;
+    }
+}

--- a/src/main/java/com/wenglam/baking_app/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wenglam/baking_app/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
                 ErrorResponseDto errorResponseDto = new ErrorResponseDto(
                                 httpServletRequest.getRequestURI(),
                                 HttpStatus.INTERNAL_SERVER_ERROR,
-                                exception.getMessage(),
+                                exception.getMessage(), // TODO: remove in production
                                 LocalDateTime.now());
 
                 log.error("500 Unexpected {} {}", httpServletRequest.getMethod(), httpServletRequest.getRequestURI(), exception);
@@ -46,7 +46,7 @@ public class GlobalExceptionHandler {
 
                 ErrorResponseDto errorResponseDto = new ErrorResponseDto(
                                 httpServletRequest.getRequestURI(),
-                                HttpStatus.INTERNAL_SERVER_ERROR,
+                                HttpStatus.BAD_REQUEST,
                                 errors.toString(),
                                 LocalDateTime.now());
                 
@@ -114,7 +114,7 @@ public class GlobalExceptionHandler {
                 return new ResponseEntity<>(errorResponseDto, HttpStatus.FORBIDDEN);
         }
 
-        @ExceptionHandler(TastyRecipeNotFoundException.class) // Http status code: 403
+        @ExceptionHandler(TastyRecipeNotFoundException.class) // Http status code: 404
         public ResponseEntity<ErrorResponseDto> handleTastyRecipeNotFoundException(TastyRecipeNotFoundException exception,
                         HttpServletRequest httpServletRequest) {
                 ErrorResponseDto errorResponseDto = new ErrorResponseDto(

--- a/src/main/java/com/wenglam/baking_app/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wenglam/baking_app/exception/GlobalExceptionHandler.java
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
                                 HttpStatus.INTERNAL_SERVER_ERROR,
                                 exception.getMessage(),
                                 LocalDateTime.now());
-                
+
                 log.error("500 Unexpected {} {}", httpServletRequest.getMethod(), httpServletRequest.getRequestURI(), exception);
 
                 return ResponseEntity.internalServerError().body(errorResponseDto);
@@ -98,4 +98,51 @@ public class GlobalExceptionHandler {
         }
 
         // TODO: DataIntegrityViolationException - 409
+
+        // Tasty API Exceptions
+        @ExceptionHandler(ApiNotSubscribedException.class) // Http status code: 403
+        public ResponseEntity<ErrorResponseDto> handleApiNotSubscribedException(ApiNotSubscribedException exception,
+                        HttpServletRequest httpServletRequest) {
+                ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                                httpServletRequest.getRequestURI(),
+                                HttpStatus.FORBIDDEN,
+                                exception.getMessage(),
+                                LocalDateTime.now());
+
+                log.warn("403 - Forbidden {} -> {}", httpServletRequest.getRequestURI(), exception.getMessage());
+
+                return new ResponseEntity<>(errorResponseDto, HttpStatus.FORBIDDEN);
+        }
+
+        @ExceptionHandler(TastyRecipeNotFoundException.class) // Http status code: 403
+        public ResponseEntity<ErrorResponseDto> handleTastyRecipeNotFoundException(TastyRecipeNotFoundException exception,
+                        HttpServletRequest httpServletRequest) {
+                ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                                httpServletRequest.getRequestURI(),
+                                HttpStatus.NOT_FOUND,
+                                exception.getMessage(),
+                                LocalDateTime.now());
+
+                log.warn("404 - NOT FOUND {} -> {}", httpServletRequest.getRequestURI(), exception.getMessage());
+
+                return new ResponseEntity<>(errorResponseDto, HttpStatus.NOT_FOUND);
+        }
+
+        @ExceptionHandler(ExternalApiException.class) // Http status code: determined during runtime
+        public ResponseEntity<ErrorResponseDto> handleExternalApiException(ExternalApiException exception,
+                        HttpServletRequest httpServletRequest) {
+
+                        int statusCode = exception.getStatusCode();
+                        HttpStatus httpStatus = HttpStatus.resolve(statusCode) != null ? HttpStatus.resolve(statusCode) : HttpStatus.INTERNAL_SERVER_ERROR;
+
+                ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                                httpServletRequest.getRequestURI(),
+                                httpStatus,
+                                exception.getMessage(),
+                                LocalDateTime.now());
+
+                log.warn(exception.getStatusCode() + " " + httpStatus.getReasonPhrase() + " {} -> {}", httpServletRequest.getRequestURI(), exception.getMessage());
+
+                return new ResponseEntity<>(errorResponseDto, httpStatus);
+        }
 }

--- a/src/main/java/com/wenglam/baking_app/exception/TastyRecipeNotFoundException.java
+++ b/src/main/java/com/wenglam/baking_app/exception/TastyRecipeNotFoundException.java
@@ -4,5 +4,4 @@ public class TastyRecipeNotFoundException extends RuntimeException {
     public TastyRecipeNotFoundException(String message) {
         super(message);
     }
-    
 }

--- a/src/main/java/com/wenglam/baking_app/exception/TastyRecipeNotFoundException.java
+++ b/src/main/java/com/wenglam/baking_app/exception/TastyRecipeNotFoundException.java
@@ -1,0 +1,8 @@
+package com.wenglam.baking_app.exception;
+
+public class TastyRecipeNotFoundException extends RuntimeException {
+    public TastyRecipeNotFoundException(String message) {
+        super(message);
+    }
+    
+}

--- a/src/main/java/com/wenglam/baking_app/external/tasty/TastyClient.java
+++ b/src/main/java/com/wenglam/baking_app/external/tasty/TastyClient.java
@@ -5,7 +5,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "tastyClient", url = "https://tasty.p.rapidapi.com/recipes")
+import com.wenglam.baking_app.config.TastyFeignConfig;
+
+@FeignClient(
+    name = "tastyClient",
+    url = "https://tasty.p.rapidapi.com/recipes",
+    configuration = TastyFeignConfig.class)
 public interface TastyClient {
 
     @GetMapping("/list")

--- a/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
+++ b/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
@@ -14,15 +14,14 @@ public class TastyErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
 
+        log.info("Method Key: {}. Response: {}", methodKey, response.toString());
+
         switch (response.status()) {
             case 403:
-                log.info("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new ApiNotSubscribedException("You are not subscribed to Tasty API: " + response.status());
             case 404:
-                log.info("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new TastyRecipeNotFoundException("Tasty recipe not found: " + response.status());
             default:
-                log.error("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new ExternalApiException(
                     "Tasty",
                     response.status(),

--- a/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
+++ b/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
@@ -1,0 +1,29 @@
+package com.wenglam.baking_app.external.tasty;
+
+import com.wenglam.baking_app.exception.ApiNotSubscribedException;
+import com.wenglam.baking_app.exception.ExternalApiException;
+import com.wenglam.baking_app.exception.TastyRecipeNotFoundException;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class TastyErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+
+        switch (response.status()) {
+            case 403:
+                return new ApiNotSubscribedException("You are not subscribed to Tasty API: " + response.status());
+            case 404:
+                return new TastyRecipeNotFoundException("Tasty recipe not found: " + response.status());
+            default:
+                return new ExternalApiException(
+                    "Tasty",
+                    response.status(),
+                    "Error calling Tasty API: (status code: " + response.status() + ")",
+                    null
+                );
+        }
+    }
+}

--- a/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
+++ b/src/main/java/com/wenglam/baking_app/external/tasty/TastyErrorDecoder.java
@@ -6,7 +6,9 @@ import com.wenglam.baking_app.exception.TastyRecipeNotFoundException;
 
 import feign.Response;
 import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TastyErrorDecoder implements ErrorDecoder {
 
     @Override
@@ -14,10 +16,13 @@ public class TastyErrorDecoder implements ErrorDecoder {
 
         switch (response.status()) {
             case 403:
+                log.info("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new ApiNotSubscribedException("You are not subscribed to Tasty API: " + response.status());
             case 404:
+                log.info("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new TastyRecipeNotFoundException("Tasty recipe not found: " + response.status());
             default:
+                log.error("Method Key: {}. Response: {}", methodKey, response.toString());
                 return new ExternalApiException(
                     "Tasty",
                     response.status(),

--- a/src/main/java/com/wenglam/baking_app/service/impl/RecipeService.java
+++ b/src/main/java/com/wenglam/baking_app/service/impl/RecipeService.java
@@ -69,7 +69,7 @@ public class RecipeService {
             totalElements,
             dessertRecipeResponseDtos,
             pageable.getPageNumber() + 1,
-            dessertRecipeResponseDtos.size(),
+            pageable.getPageSize(),
             totalPages,
             isLast
         );


### PR DESCRIPTION
TastyApiProperties
- updated init method to log warning if api host or key is empty

TastyFeignConfig
- new config class for tasty - returning logger and TastyErrorDecoder

ApiNotSubscribedException, ExternalApiException, TastyRecipeNotFoundException
- domain exceptions specific to Tasty Client

GlobalExceptionHandler
- added exception handlers for Tasty Client exceptions

TastyErrorDecoder
- custom decoder to map FeignExceptions to specific domain exception classes, which are then routed to GlobalExceptionHandler

TastyClient
- updated properties to include configuration as TastyFeignConfig.class

RecipeService
- updated getDessertRecipes method: return object of PageResponse - pageSize of PageResponse to pageable.getPageSize()